### PR TITLE
Add --leiden flag for connected community detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,11 @@ endif()
 # ParHIP
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/app)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/KaHIP/app)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/KaHIP/lib)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/app)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/KaHIP/lib/io)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/KaHIP/lib/partition)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/KaHIP/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement)
@@ -93,8 +93,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/KaHIP/lib/tools)
 
 
 
-set(LIBPADYGRCL_FILES 
+set(LIBPADYGRCL_FILES
 lib/clustering/louvainmethod.cpp
+lib/clustering/leidenmethod.cpp
+lib/clustering/connectivity.cpp
 lib/clustering/labelpropagation.cpp
 lib/clustering/neighborhood.cpp
 lib/clustering/coarsening/contractor.cpp
@@ -186,6 +188,8 @@ lib/parallel_mh_clustering/population_clustering.cpp
 lib/parallel_mh_clustering/exchange/exchanger_clustering.cpp
 lib/tools/graph_communication.cpp
 lib/clustering/louvainmethod.cpp
+lib/clustering/leidenmethod.cpp
+lib/clustering/connectivity.cpp
 lib/clustering/labelpropagation.cpp
 lib/clustering/neighborhood.cpp
 lib/clustering/coarsening/coarsening.cpp

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ VieClus v1.2
 | **What it solves** | Graph clustering: detecting tightly connected regions (communities) in a graph |
 | **Objective** | Maximize [modularity](https://en.wikipedia.org/wiki/Modularity_(networks)) |
 | **Key result** | Improves or reproduces **all entries** of the 10th DIMACS Implementation Challenge |
-| **Algorithm** | Memetic (evolutionary) algorithm with multilevel techniques and ensemble recombination |
+| **Algorithm** | Memetic (evolutionary) algorithm with multilevel techniques and ensemble recombination. Optional Leiden mode guarantees connected communities. |
 | **Interfaces** | CLI, Python (`pip install vieclus`), C/C++ library |
 | **Parallel** | Optional MPI support for parallel evolutionary search |
 
@@ -88,6 +88,8 @@ mpirun -n P vieclus <graph-file> [options]
 | `--time_limit=<double>` | Time limit in seconds. Must be > 0 to enable evolutionary recombination. | `0` |
 | `--seed=<int>` | Random seed | `0` |
 | `--output_filename=<string>` | Output file for the clustering | `tmpclustering` |
+| `--leiden` | Use Leiden algorithm (guarantees connected communities) | off |
+| `--leiden_theta=<double>` | Leiden refinement temperature parameter | `0.01` |
 | `--help` | Print help | |
 
 **Included tools:**
@@ -282,6 +284,21 @@ VieClus is a **memetic algorithm** that combines evolutionary search with multil
 3. **Parallel search** (with MPI): Multiple processes explore the solution space independently and exchange high-quality individuals, improving diversity and convergence.
 
 More time and more MPI processes generally yield better modularity values. For details, see the [paper](https://arxiv.org/abs/1802.07034).
+
+### Leiden Mode (`--leiden`)
+
+When `--leiden` is passed, VieClus uses the [Leiden algorithm](https://www.nature.com/articles/s41598-019-41695-z) (Traag, Waltman, van Eck, 2019) instead of Louvain as its core clustering method. This guarantees that all output communities are connected subgraphs. The implementation uses three phases per multilevel iteration:
+
+1. **Fast local moving** (queue-based): only revisits nodes whose neighbors changed, making it faster than Louvain's full sweeps.
+2. **Refinement**: within each community, restarts from singletons and stochastically merges nodes into adjacent sub-communities. Since only singleton nodes can move, connectivity is guaranteed by construction.
+3. **Dual-partition aggregation**: aggregates based on the refined partition, but initializes the next level with the coarser partition from phase 1.
+
+All evolutionary operators additionally enforce connectivity via BFS-based splitting when `--leiden` is active.
+
+**Example:**
+```bash
+mpirun -n 4 ./deploy/vieclus mygraph.graph --leiden --time_limit=60
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-VieClus v1.2
+VieClus v1.3
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![C++](https://img.shields.io/badge/C++-11/14-blue.svg)](https://isocpp.org/)
 [![CMake](https://img.shields.io/badge/CMake-3.10+-064F8C.svg)](https://cmake.org/)
@@ -314,6 +314,13 @@ mpirun -n 4 ./deploy/vieclus mygraph.graph --leiden --time_limit=60
 ---
 
 ## Release Notes
+
+### v1.3
+- Added `--leiden` flag: Leiden algorithm guaranteeing connected communities
+- Added `--leiden_theta` parameter for refinement temperature control
+- Leiden uses queue-based local moving, stochastic refinement, and dual-partition aggregation
+- All evolutionary operators enforce connectivity when `--leiden` is active
+- Fixed include directory ordering in CMakeLists.txt
 
 ### v1.2
 - Added Python interface (`pip install vieclus`) with pybind11 bindings

--- a/app/evo_clustering.cpp
+++ b/app/evo_clustering.cpp
@@ -24,6 +24,7 @@
 #include "macros_assertions.h"
 #include "parallel_mh_clustering/parallel_mh_async_clustering.h"
 #include "parse_parameters.h"
+#include "clustering/leiden_config.h"
 #include "partition/graph_partitioner.h"
 #include "partition/partition_config.h"
 #include "quality_metrics.h"
@@ -39,15 +40,16 @@ int main(int argn, char **argv) {
 #endif    /* starts MPI */
 
         PartitionConfig partition_config;
+        LeidenConfig leiden_config;
         std::string graph_filename;
         bool is_graph_weighted = false;
         bool suppress_output   = false;
         bool recursive         = false;
 
-        int ret_code = parse_parameters(argn, argv, 
-                        partition_config, graph_filename, 
-                        is_graph_weighted, suppress_output, 
-                        recursive); 
+        int ret_code = parse_parameters(argn, argv,
+                        partition_config, graph_filename,
+                        is_graph_weighted, suppress_output,
+                        recursive, leiden_config); 
 
         if(ret_code) {
                 return 0;
@@ -65,7 +67,7 @@ int main(int argn, char **argv) {
         t.restart();
         
         partition_config.k = 1;
-        parallel_mh_async_clustering mh;
+        parallel_mh_async_clustering mh(leiden_config);
         mh.perform_partitioning(partition_config, G);
 
         int rank, size;

--- a/app/parse_parameters.h
+++ b/app/parse_parameters.h
@@ -18,13 +18,17 @@
 #endif
 #include <sstream>
 #include "configuration.h"
+#include "clustering/leiden_config.h"
+
+static LeidenConfig _default_leiden_config;
 
 int parse_parameters(int argn, char **argv,
                      PartitionConfig & partition_config,
                      std::string & graph_filename,
                      bool & is_graph_weighted,
                      bool & suppress_program_output,
-                     bool & recursive) {
+                     bool & recursive,
+                     LeidenConfig & leiden_config = _default_leiden_config) {
 
         const char *progname = argv[0];
 
@@ -49,6 +53,8 @@ int parse_parameters(int argn, char **argv,
         struct arg_str *output_log_json                             = arg_str0(NULL, "output_log_json", NULL, "File to write the log in JSON format into it. Use \"-\" to write to STDOUT. (Default: disabled)");
 
         struct arg_int *mh_pool_size                         = arg_int0(NULL, "mh_pool_size", NULL, "MetaHeuristic Pool Size.");
+        struct arg_lit *leiden                               = arg_lit0(NULL, "leiden", "Use Leiden algorithm (guarantees connected communities).");
+        struct arg_dbl *leiden_theta                         = arg_dbl0(NULL, "leiden_theta", NULL, "Leiden refinement temperature parameter. Default: 0.01.");
         struct arg_end *end                                  = arg_end(100);
 
         // Define argtable.
@@ -58,10 +64,12 @@ int parse_parameters(int argn, char **argv,
                 time_limit,
                 //mh_pool_size,
                 //mh_mutate_fraction,
-		//mh_print_log, 
+		//mh_print_log,
                 //local_partitioning_repetitions,
                 //input_partition,
                 filename_output,
+                leiden,
+                leiden_theta,
 #elif defined MODE_EVALUATOR
                 input_partition,
 #elif defined MODE_CLUSTERING
@@ -72,6 +80,8 @@ int parse_parameters(int argn, char **argv,
     // if we use size constrained label propagation
     lm_cluster_coarsening_factor,
     output_log_json,
+    leiden,
+    leiden_theta,
 #endif
                 end
         };
@@ -165,6 +175,14 @@ int parse_parameters(int argn, char **argv,
 
         if (output_log_json->count > 0) {
             partition_config.outputLogJsonFileName = output_log_json->sval[0];
+        }
+
+        if(leiden->count > 0) {
+                leiden_config.enabled = true;
+        }
+
+        if(leiden_theta->count > 0) {
+                leiden_config.theta = leiden_theta->dval[0];
         }
 
         if(mh_mutate_fraction->count > 0) {

--- a/lib/clustering/connectivity.cpp
+++ b/lib/clustering/connectivity.cpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * connectivity.cpp
+ *
+ * Source of VieClus -- Vienna Graph Clustering
+ *****************************************************************************/
+
+
+#include "connectivity.h"
+
+#include <queue>
+#include <unordered_map>
+#include <vector>
+
+PartitionID splitDisconnectedCommunities(graph_access &G) {
+        NodeID n = G.number_of_nodes();
+        PartitionID num_clusters = G.get_partition_count();
+
+        // build per-cluster node lists
+        std::vector<std::vector<NodeID>> cluster_nodes(num_clusters);
+        forall_nodes(G, node) {
+                cluster_nodes[G.getPartitionIndex(node)].push_back(node);
+        } endfor
+
+        std::vector<bool> visited(n, false);
+        PartitionID next_id = num_clusters;
+
+        for (PartitionID c = 0; c < num_clusters; ++c) {
+                if (cluster_nodes[c].empty()) continue;
+
+                unsigned component_count = 0;
+                for (NodeID seed : cluster_nodes[c]) {
+                        if (visited[seed]) continue;
+
+                        // BFS within cluster c
+                        std::queue<NodeID> bfs_queue;
+                        std::vector<NodeID> component;
+                        bfs_queue.push(seed);
+                        visited[seed] = true;
+
+                        while (!bfs_queue.empty()) {
+                                NodeID cur = bfs_queue.front();
+                                bfs_queue.pop();
+                                component.push_back(cur);
+
+                                forall_out_edges(G, e, cur) {
+                                        NodeID target = G.getEdgeTarget(e);
+                                        if (!visited[target] && G.getPartitionIndex(target) == c) {
+                                                visited[target] = true;
+                                                bfs_queue.push(target);
+                                        }
+                                } endfor
+                        }
+
+                        // first component keeps original ID, others get new IDs
+                        if (component_count > 0) {
+                                for (NodeID v : component) {
+                                        G.setPartitionIndex(v, next_id);
+                                }
+                                next_id++;
+                        }
+                        component_count++;
+                }
+        }
+
+        // remap to consecutive IDs [0, k-1]
+        std::unordered_map<PartitionID, PartitionID> new_mapping;
+        PartitionID id = 0;
+
+        forall_nodes(G, node) {
+                PartitionID cluster = G.getPartitionIndex(node);
+                if (!new_mapping.count(cluster)) { new_mapping[cluster] = id++; }
+                G.setPartitionIndex(node, new_mapping[cluster]);
+        } endfor
+
+        G.set_partition_count(id);
+        return id;
+}

--- a/lib/clustering/connectivity.h
+++ b/lib/clustering/connectivity.h
@@ -1,0 +1,17 @@
+/******************************************************************************
+ * connectivity.h
+ *
+ * Source of VieClus -- Vienna Graph Clustering
+ *****************************************************************************/
+
+
+#ifndef CONNECTIVITY_H
+#define CONNECTIVITY_H
+
+#include "data_structure/graph_access.h"
+
+// Splits disconnected communities into connected components.
+// Modifies partition indices in-place. Returns new partition count.
+PartitionID splitDisconnectedCommunities(graph_access &G);
+
+#endif // CONNECTIVITY_H

--- a/lib/clustering/leiden_config.h
+++ b/lib/clustering/leiden_config.h
@@ -1,0 +1,18 @@
+/******************************************************************************
+ * leiden_config.h
+ *
+ * Source of VieClus -- Vienna Graph Clustering
+ *****************************************************************************/
+
+
+#ifndef LEIDEN_CONFIG_H
+#define LEIDEN_CONFIG_H
+
+struct LeidenConfig {
+        bool enabled;
+        double theta;
+        LeidenConfig() : enabled(false), theta(0.01) {}
+        LeidenConfig(bool e, double t) : enabled(e), theta(t) {}
+};
+
+#endif // LEIDEN_CONFIG_H

--- a/lib/clustering/leidenmethod.cpp
+++ b/lib/clustering/leidenmethod.cpp
@@ -1,0 +1,402 @@
+/******************************************************************************
+ * leidenmethod.cpp
+ *
+ * Source of VieClus -- Vienna Graph Clustering
+ *****************************************************************************/
+
+
+#include "leidenmethod.h"
+
+#include "clustering/coarsening/coarsening.h"
+#include "clustering/labelpropagation.h"
+#include "clustering/neighborhood.h"
+#include "clustering/connectivity.h"
+#include "coarsening/clustering/size_constraint_label_propagation.h"
+#include "partition/coarsening/clustering/node_ordering.h"
+#include "tools/modularitymetric.h"
+#include "tools/random_functions.h"
+
+#include <algorithm>
+#include <cmath>
+#include <list>
+#include <numeric>
+#include <unordered_map>
+#include <vector>
+
+using namespace std;
+
+LeidenMethod::LeidenMethod()
+    : m_G(0)
+{
+}
+
+LeidenMethod::~LeidenMethod()
+{
+}
+
+PartitionID LeidenMethod::performClustering(PartitionConfig &config, graph_access *G, bool start_w_singletons)
+{
+    return LeidenMethod::performClusteringWithLPP(config, G, start_w_singletons);
+}
+
+PartitionID LeidenMethod::performClusteringWithLPP(const PartitionConfig& config,
+                                                    graph_access* G, bool start_w_singletons)
+{
+    NodeID numberOfMoves = 0;
+    unsigned coarsenings = 0;
+    graph_hierarchy graphHierarchy;
+    list<graph_access *> coarseGraphsToDelete;
+
+    m_G = G;
+
+    // optional label propagation preprocessing (same as Louvain)
+    for (unsigned i = 0; i < config.lm_number_of_label_propagation_levels; ++i)
+    {
+        if (start_w_singletons) { initializeSingletonClusters(); }
+
+        if (config.lm_cluster_coarsening_factor > 0)
+        {
+            NodeID no_blocks = 0;
+            std::vector<NodeID> cluster_id;
+            size_constraint_label_propagation sclp;
+            sclp.label_propagation(config, *m_G, cluster_id, no_blocks);
+
+            forall_nodes((*m_G), node) {
+                m_G->setPartitionIndex(node, cluster_id[node]);
+            } endfor
+
+            // enforce connectivity after size-constrained LP
+            splitDisconnectedCommunities(*m_G);
+
+            numberOfMoves = 1;
+        }
+        else
+        {
+            numberOfMoves = LabelPropagation::performLabelPropagation(config, m_G);
+            // enforce connectivity after LP
+            splitDisconnectedCommunities(*m_G);
+        }
+
+        if (numberOfMoves)
+        {
+            m_G = Coarsening::performCoarsening(config, *m_G, graphHierarchy, coarseGraphsToDelete);
+            coarsenings++;
+        }
+
+        if (!numberOfMoves)
+        {
+            break;
+        }
+    }
+
+    // main Leiden loop: Phase 1 (fast local move) + Phase 2 (refinement) + Phase 3 (aggregation)
+    do
+    {
+        if (start_w_singletons) { initializeSingletonClusters(); }
+
+        // Phase 1: fast local moving (queue-based)
+        numberOfMoves = performFastLocalMove(config);
+
+        if (numberOfMoves)
+        {
+            // save the flat (non-refined) partition from Phase 1
+            vector<PartitionID> flatPartition(m_G->number_of_nodes());
+            forall_nodes((*m_G), node) {
+                flatPartition[node] = m_G->getPartitionIndex(node);
+            } endfor
+
+            // Phase 2: refinement (guarantees connected communities)
+            performRefinement(config, flatPartition);
+
+            // Phase 3: aggregate based on refined partition
+            m_G = Coarsening::performCoarsening(config, *m_G, graphHierarchy, coarseGraphsToDelete);
+            coarsenings++;
+
+            // Initialize next level with flat (non-refined) partition projected onto coarse graph.
+            // The coarse graph nodes correspond to refined sub-communities.
+            // We need to map each coarse node back to its flat partition community.
+            // After coarsening, partition indices on coarse graph are initialized by the contractor.
+            // We override them with the flat partition mapping.
+            //
+            // Each node in the coarse graph represents a refined sub-community.
+            // We find which flat community it belongs to by looking at the mapping.
+            CoarseMapping* mapping = graphHierarchy.get_mapping_of_current_finer();
+            if (mapping != nullptr) {
+                // mapping[fine_node] = coarse_node
+                // flatPartition[fine_node] = flat community
+                // For each coarse node, pick the flat community of any constituent fine node
+                NodeID coarse_n = m_G->number_of_nodes();
+                vector<PartitionID> coarse_flat(coarse_n, 0);
+                vector<bool> assigned(coarse_n, false);
+
+                NodeID fine_n = flatPartition.size();
+                for (NodeID fine_node = 0; fine_node < fine_n; ++fine_node) {
+                    NodeID coarse_node = (*mapping)[fine_node];
+                    if (!assigned[coarse_node]) {
+                        coarse_flat[coarse_node] = flatPartition[fine_node];
+                        assigned[coarse_node] = true;
+                    }
+                }
+
+                // remap flat community IDs to consecutive range
+                unordered_map<PartitionID, PartitionID> flat_remap;
+                PartitionID fid = 0;
+                for (NodeID cn = 0; cn < coarse_n; ++cn) {
+                    if (!flat_remap.count(coarse_flat[cn])) {
+                        flat_remap[coarse_flat[cn]] = fid++;
+                    }
+                    m_G->setPartitionIndex(cn, flat_remap[coarse_flat[cn]]);
+                }
+                m_G->set_partition_count(fid);
+
+                // next iteration will NOT start with singletons since we initialized
+                // from the flat partition
+                start_w_singletons = false;
+            }
+        }
+    }
+    while (numberOfMoves);
+
+    // append the last level
+    graphHierarchy.push_back(m_G, 0);
+
+    // uncoarsening with refinement
+    while (coarsenings > 0 && !graphHierarchy.isEmpty())
+    {
+        m_G = graphHierarchy.pop_finer_and_project();
+        numberOfMoves = performFastLocalMove(config);
+    }
+
+    // cleanup coarse graphs
+    while (!coarseGraphsToDelete.empty())
+    {
+        delete coarseGraphsToDelete.front();
+        coarseGraphsToDelete.pop_front();
+    }
+
+    // final connectivity enforcement
+    splitDisconnectedCommunities(*m_G);
+
+    // remap cluster IDs to consecutive range
+    std::unordered_map<PartitionID, PartitionID> new_mapping;
+    PartitionID id = 0;
+
+    forall_nodes((*m_G), node) {
+        PartitionID cluster = m_G->getPartitionIndex(node);
+        if (!new_mapping.count(cluster)) { new_mapping[cluster] = id++; }
+        m_G->setPartitionIndex(node, new_mapping[cluster]);
+    } endfor
+
+    m_G->set_partition_count(id);
+
+    return m_G->get_partition_count();
+}
+
+
+void LeidenMethod::initializeSingletonClusters()
+{
+    PartitionID clusterID = 0;
+    forall_nodes((*m_G), n)
+    {
+        m_G->setPartitionIndex(n, clusterID);
+        clusterID++;
+    } endfor
+    m_G->set_partition_count(clusterID);
+}
+
+
+NodeID LeidenMethod::performFastLocalMove(const PartitionConfig &config)
+{
+    NodeID numberOfMoves = 0;
+    bool hasGraphSelfLoops = m_G->containsSelfLoops();
+    Neighborhood neighborhood;
+    neighborhood.initialize(m_G);
+
+    ModularityMetric *objective = new ModularityMetric(*m_G);
+
+    NodeID n = m_G->number_of_nodes();
+
+    // queue-based: start with all nodes in random order
+    vector<NodeID> perm(n);
+    random_functions::permutate_vector_good(perm, true);
+
+    queue<NodeID> node_queue;
+    vector<bool> in_queue(n, false);
+
+    for (NodeID i = 0; i < n; ++i) {
+        node_queue.push(perm[i]);
+        in_queue[perm[i]] = true;
+    }
+
+    while (!node_queue.empty())
+    {
+        NodeID node = node_queue.front();
+        node_queue.pop();
+        in_queue[node] = false;
+
+        neighborhood.update(node);
+
+        if (neighborhood.getNumberOfNeighboringClusters() > 1)
+        {
+            PartitionID oldCluster = m_G->getPartitionIndex(node);
+            PartitionID bestCluster = oldCluster;
+            double bestGain = 0.0;
+            EdgeWeight selfLoop = 0;
+
+            if (hasGraphSelfLoops)
+            {
+                selfLoop = m_G->getSelfLoop(node);
+            }
+
+            objective->removeNode(node, oldCluster, neighborhood.getEdgeWeightToNeighboringCluster(oldCluster), selfLoop);
+
+            for (NodeID i = 0; i < neighborhood.getNumberOfNeighboringClusters(); ++i)
+            {
+                PartitionID newCluster = neighborhood.getClusterIDOfNeighbor(i);
+                double gain = objective->gain(node, newCluster, neighborhood.getEdgeWeightToNeighboringCluster(newCluster));
+
+                if (bestGain < gain)
+                {
+                    bestGain = gain;
+                    bestCluster = newCluster;
+                }
+            }
+
+            objective->insertNode(node, bestCluster, neighborhood.getEdgeWeightToNeighboringCluster(bestCluster), selfLoop);
+
+            if (oldCluster != bestCluster)
+            {
+                numberOfMoves++;
+                // enqueue neighbors that are not already queued
+                forall_out_edges((*m_G), e, node) {
+                    NodeID neighbor = m_G->getEdgeTarget(e);
+                    if (!in_queue[neighbor]) {
+                        node_queue.push(neighbor);
+                        in_queue[neighbor] = true;
+                    }
+                } endfor
+            }
+        }
+    }
+
+    delete objective;
+    return numberOfMoves;
+}
+
+
+void LeidenMethod::performRefinement(const PartitionConfig &config,
+                                      const std::vector<PartitionID> &flatPartition)
+{
+    NodeID n = m_G->number_of_nodes();
+    bool hasGraphSelfLoops = m_G->containsSelfLoops();
+
+    // build per-community node lists from the flat partition
+    PartitionID numFlatClusters = *max_element(flatPartition.begin(), flatPartition.end()) + 1;
+    vector<vector<NodeID>> communityNodes(numFlatClusters);
+    for (NodeID node = 0; node < n; ++node) {
+        communityNodes[flatPartition[node]].push_back(node);
+    }
+
+    // reset all nodes to singletons (refined partition starts from scratch)
+    initializeSingletonClusters();
+
+    // track which nodes are still singletons (have not been merged)
+    vector<bool> isSingleton(n, true);
+
+    // create modularity objective for the singleton state
+    ModularityMetric *objective = new ModularityMetric(*m_G);
+
+    double theta = m_leiden_config.theta;
+
+    // for each community in the flat partition, refine
+    for (PartitionID c = 0; c < numFlatClusters; ++c)
+    {
+        vector<NodeID>& nodes = communityNodes[c];
+        if (nodes.size() <= 1) continue;
+
+        // shuffle nodes within this community
+        for (size_t i = nodes.size() - 1; i > 0; --i) {
+            size_t j = random_functions::nextInt(0, i);
+            swap(nodes[i], nodes[j]);
+        }
+
+        for (NodeID node : nodes)
+        {
+            if (!isSingleton[node]) continue;
+
+            // find adjacent refined sub-communities within the same flat community
+            PartitionID myCluster = m_G->getPartitionIndex(node);
+            EdgeWeight selfLoop = hasGraphSelfLoops ? m_G->getSelfLoop(node) : 0;
+
+            // collect candidates: neighboring refined clusters within same flat community C
+            struct Candidate {
+                PartitionID cluster;
+                EdgeWeight edgeWeight;
+                double deltaQ;
+            };
+            vector<Candidate> candidates;
+            double totalWeight = 0.0;
+
+            // compute edge weights to neighboring refined clusters within C
+            unordered_map<PartitionID, EdgeWeight> edgeWeightToCluster;
+            forall_out_edges((*m_G), e, node) {
+                NodeID neighbor = m_G->getEdgeTarget(e);
+                if (flatPartition[neighbor] == c) {
+                    PartitionID neighborCluster = m_G->getPartitionIndex(neighbor);
+                    if (neighborCluster != myCluster) {
+                        edgeWeightToCluster[neighborCluster] += m_G->getEdgeWeight(e);
+                    }
+                }
+            } endfor
+
+            if (edgeWeightToCluster.empty()) continue;
+
+            // temporarily remove node from its singleton cluster
+            EdgeWeight edgeWeightToOwn = 0;
+            forall_out_edges((*m_G), e, node) {
+                NodeID neighbor = m_G->getEdgeTarget(e);
+                if (m_G->getPartitionIndex(neighbor) == myCluster) {
+                    edgeWeightToOwn += m_G->getEdgeWeight(e);
+                }
+            } endfor
+
+            objective->removeNode(node, myCluster, edgeWeightToOwn, selfLoop);
+
+            for (auto& kv : edgeWeightToCluster) {
+                double gain = objective->gain(node, kv.first, kv.second);
+                if (gain > 0) {
+                    double weight = exp(gain / theta);
+                    candidates.push_back({kv.first, kv.second, gain});
+                    totalWeight += weight;
+                }
+            }
+
+            if (candidates.empty()) {
+                // put node back in its own cluster
+                objective->insertNode(node, myCluster, edgeWeightToOwn, selfLoop);
+                continue;
+            }
+
+            // stochastic selection proportional to exp(deltaQ / theta)
+            double r = random_functions::nextDouble(0.0, totalWeight);
+            double cumulative = 0.0;
+            PartitionID selectedCluster = candidates[0].cluster;
+            EdgeWeight selectedEdgeWeight = candidates[0].edgeWeight;
+
+            for (auto& cand : candidates) {
+                cumulative += exp(cand.deltaQ / theta);
+                if (cumulative >= r) {
+                    selectedCluster = cand.cluster;
+                    selectedEdgeWeight = cand.edgeWeight;
+                    break;
+                }
+            }
+
+            // merge node into selected sub-community
+            objective->insertNode(node, selectedCluster, selectedEdgeWeight, selfLoop);
+            isSingleton[node] = false;
+        }
+    }
+
+    delete objective;
+}

--- a/lib/clustering/leidenmethod.h
+++ b/lib/clustering/leidenmethod.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * leidenmethod.h
+ *
+ * Source of VieClus -- Vienna Graph Clustering
+ *****************************************************************************/
+
+
+#ifndef LEIDENMETHOD_H
+#define LEIDENMETHOD_H
+
+#include "data_structure/graph_access.h"
+#include "data_structure/graph_hierarchy.h"
+#include "partition/partition_config.h"
+#include "clustering/leiden_config.h"
+
+#include <vector>
+#include <queue>
+
+class LeidenMethod
+{
+    public:
+        LeidenMethod();
+        virtual ~LeidenMethod();
+
+        PartitionID performClustering(PartitionConfig &config,
+                                      graph_access *G, bool = true);
+
+        PartitionID performClusteringWithLPP(const PartitionConfig &config,
+                                             graph_access *G, bool = true);
+
+        void setLeidenConfig(const LeidenConfig &lc) { m_leiden_config = lc; }
+
+    protected:
+        void initializeSingletonClusters();
+
+        // Phase 1: fast queue-based local moving
+        NodeID performFastLocalMove(const PartitionConfig &config);
+
+        // Phase 2: refinement within communities from phase 1
+        void performRefinement(const PartitionConfig &config,
+                               const std::vector<PartitionID> &flatPartition);
+
+        graph_access *m_G;
+        LeidenConfig m_leiden_config;
+
+    private:
+};
+
+#endif // LEIDENMETHOD_H

--- a/lib/parallel_mh_clustering/parallel_mh_async_clustering.cpp
+++ b/lib/parallel_mh_clustering/parallel_mh_async_clustering.cpp
@@ -33,6 +33,16 @@ parallel_mh_async_clustering::parallel_mh_async_clustering() : MASTER(0), m_time
         MPI_Comm_size( m_communicator, &m_size);
 }
 
+parallel_mh_async_clustering::parallel_mh_async_clustering(const LeidenConfig & leiden_config) : MASTER(0), m_time_limit(0), m_leiden_config(leiden_config) {
+        m_best_global_objective = std::numeric_limits<EdgeWeight>::max();
+        m_best_cycle_objective  = std::numeric_limits<EdgeWeight>::max();
+        m_rounds                = 0;
+        m_termination           = false;
+        m_communicator          = MPI_COMM_WORLD;
+        MPI_Comm_rank( m_communicator, &m_rank);
+        MPI_Comm_size( m_communicator, &m_size);
+}
+
 parallel_mh_async_clustering::parallel_mh_async_clustering(MPI_Comm communicator) : MASTER(0), m_time_limit(0) {
         m_best_global_objective = std::numeric_limits<EdgeWeight>::max();
         m_best_cycle_objective  = std::numeric_limits<EdgeWeight>::max();
@@ -50,7 +60,7 @@ parallel_mh_async_clustering::~parallel_mh_async_clustering() {
 
 void parallel_mh_async_clustering::perform_partitioning(const PartitionConfig & partition_config, graph_access & G) {
         m_time_limit      = partition_config.time_limit;
-        m_island          = new population_clustering(m_communicator, partition_config);
+        m_island          = new population_clustering(m_communicator, partition_config, m_leiden_config);
         m_best_global_map = new PartitionID[G.number_of_nodes()];
 
         srand(partition_config.seed*m_size+m_rank);

--- a/lib/parallel_mh_clustering/parallel_mh_async_clustering.h
+++ b/lib/parallel_mh_clustering/parallel_mh_async_clustering.h
@@ -15,11 +15,13 @@
 #include "data_structure/graph_access.h"
 #include "partition_config.h"
 #include "population_clustering.h"
+#include "clustering/leiden_config.h"
 #include "tools/global_timer.h"
 
 class parallel_mh_async_clustering {
 public:
         parallel_mh_async_clustering();
+        parallel_mh_async_clustering(const LeidenConfig & leiden_config);
         parallel_mh_async_clustering(MPI_Comm communicator);
         virtual ~parallel_mh_async_clustering();
 
@@ -46,6 +48,7 @@ private:
         //island
         population_clustering* m_island;
         MPI_Comm m_communicator;
+        LeidenConfig m_leiden_config;
 };
 
 

--- a/lib/parallel_mh_clustering/population_clustering.cpp
+++ b/lib/parallel_mh_clustering/population_clustering.cpp
@@ -25,12 +25,14 @@
 #include "tools/global_timer.h"
 #include "uncoarsening/refinement/cycle_improvements/cycle_refinement.h"
 #include "clustering/louvainmethod.h"
+#include "clustering/leidenmethod.h"
+#include "clustering/connectivity.h"
 #include "clustering/coarsening/contractor.h"
 #include "partition/coarsening/clustering/size_constraint_label_propagation.h"
 #include "tools/modularitymetric.h"
 #include "tools/graph_extractor.h"
 
-population_clustering::population_clustering( MPI_Comm communicator, const PartitionConfig & partition_config ) {
+population_clustering::population_clustering( MPI_Comm communicator, const PartitionConfig & partition_config, const LeidenConfig & leiden_config ) {
         m_population_clustering_size    = partition_config.mh_pool_size;
         m_no_partition_calls = 0;
         m_num_NCs            = partition_config.mh_num_ncs_to_compute;
@@ -38,8 +40,16 @@ population_clustering::population_clustering( MPI_Comm communicator, const Parti
         m_num_ENCs           = 0;
         m_time_stamp         = 0;
         m_communicator       = communicator;
+        m_use_leiden         = leiden_config.enabled;
+        m_leiden_theta       = leiden_config.theta;
         global_timer_restart();
         best_objective = -1;
+}
+
+void population_clustering::do_leiden_clustering(PartitionConfig & config, graph_access & G, bool start_w_singletons) {
+        LeidenMethod lm;
+        lm.setLeidenConfig(LeidenConfig{true, m_leiden_theta});
+        lm.performClustering(config, &G, start_w_singletons);
 }
 
 population_clustering::~population_clustering() {
@@ -78,7 +88,13 @@ void population_clustering::createIndividuum(const PartitionConfig & config,
         if( lp_levels == 10) 
                 copy.lm_number_of_label_propagation_levels = 3; 
 
-        LouvainMethod{}.performClustering(copy, &G, true);
+        if (m_use_leiden) {
+                LeidenMethod lm;
+                lm.setLeidenConfig(LeidenConfig{true, m_leiden_theta});
+                lm.performClustering(copy, &G, true);
+        } else {
+                LouvainMethod{}.performClustering(copy, &G, true);
+        }
 
         int* partition_map = new int[G.number_of_nodes()];
         forall_nodes(G, node) {
@@ -208,6 +224,10 @@ void population_clustering::combine_basic_flat(const PartitionConfig & partition
         } endfor
 
         G.set_partition_count(G.get_partition_count_compute());
+        if (m_use_leiden) {
+                splitDisconnectedCommunities(G);
+                forall_nodes(G, n) { partition_map[n] = G.getPartitionIndex(n); } endfor
+        }
         output_ind.objective = ModularityMetric::computeModularity(G);
         output_ind.partition_map    = partition_map;
         output_ind.cut_edges        = new std::vector<EdgeID>();
@@ -222,10 +242,10 @@ void population_clustering::combine_basic_flat(const PartitionConfig & partition
         } endfor
 }
 
-void population_clustering::combine_improved_multilevel(const PartitionConfig & partition_config, 
-                graph_access & G, 
-                Individuum & first_ind, 
-                Individuum & second_ind, 
+void population_clustering::combine_improved_multilevel(const PartitionConfig & partition_config,
+                graph_access & G,
+                Individuum & first_ind,
+                Individuum & second_ind,
                 Individuum & output_ind) {
 
         double eps = 0.001;
@@ -299,6 +319,10 @@ void population_clustering::combine_improved_multilevel(const PartitionConfig & 
         } endfor
 
         G.set_partition_count(G.get_partition_count_compute());
+        if (m_use_leiden) {
+                splitDisconnectedCommunities(G);
+                forall_nodes(G, n) { partition_map[n] = G.getPartitionIndex(n); } endfor
+        }
         output_ind.objective = ModularityMetric::computeModularity(G);
         output_ind.partition_map    = partition_map;
         output_ind.cut_edges        = new std::vector<EdgeID>();
@@ -355,6 +379,10 @@ void population_clustering::combine_improved_flat(const PartitionConfig & partit
         } endfor
 
         G.set_partition_count(G.get_partition_count_compute());
+        if (m_use_leiden) {
+                splitDisconnectedCommunities(G);
+                forall_nodes(G, n) { partition_map[n] = G.getPartitionIndex(n); } endfor
+        }
         output_ind.objective = ModularityMetric::computeModularity(G);
         output_ind.partition_map    = partition_map;
         output_ind.cut_edges        = new std::vector<EdgeID>();
@@ -490,6 +518,10 @@ void population_clustering::combine_improved_flat_with_sclp(const PartitionConfi
         } endfor
 
         G.set_partition_count(G.get_partition_count_compute());
+        if (m_use_leiden) {
+                splitDisconnectedCommunities(G);
+                forall_nodes(G, n) { partition_map[n] = G.getPartitionIndex(n); } endfor
+        }
         output_ind.objective = ModularityMetric::computeModularity(G);
         output_ind.partition_map    = partition_map;
         output_ind.cut_edges        = new std::vector<EdgeID>();
@@ -581,6 +613,10 @@ void population_clustering::mutate_random( const PartitionConfig & partition_con
         } endfor
 
         G.set_partition_count(G.get_partition_count_compute());
+        if (m_use_leiden) {
+                splitDisconnectedCommunities(G);
+                forall_nodes(G, n) { partition_map[n] = G.getPartitionIndex(n); } endfor
+        }
         output_ind.objective = ModularityMetric::computeModularity(G);
         output_ind.partition_map    = partition_map;
         output_ind.cut_edges        = new std::vector<EdgeID>();

--- a/lib/parallel_mh_clustering/population_clustering.h
+++ b/lib/parallel_mh_clustering/population_clustering.h
@@ -22,6 +22,7 @@
 #include "partition_config.h"
 #include "tools/global_timer.h"
 #include "clustering/louvainmethod.h"
+#include "clustering/leiden_config.h"
 #include "configuration.h"
 #include "tools/modularitymetric.h"
 #include "tools/random_functions.h"
@@ -40,7 +41,7 @@ using clustering_t = std::vector<unsigned>;
 
 class population_clustering {
         public:
-                population_clustering( MPI_Comm comm, const PartitionConfig & config );
+                population_clustering( MPI_Comm comm, const PartitionConfig & config, const LeidenConfig & leiden_config = LeidenConfig() );
                 virtual ~population_clustering();
 
                 void createIndividuum(const PartitionConfig & config, 
@@ -231,7 +232,11 @@ class population_clustering {
                         partition_config.cluster_coarsening_factor = 1;
 
 
-                        LouvainMethod{ }.performClustering(partition_config, &G, c.empty());
+                        if (m_use_leiden) {
+                                do_leiden_clustering(partition_config, G, c.empty());
+                        } else {
+                                LouvainMethod{}.performClustering(partition_config, &G, c.empty());
+                        }
 
                         clustering_t clustering(G.number_of_nodes(), -1);
                         extract_clustering(G, clustering);
@@ -330,7 +335,11 @@ class population_clustering {
                         return contracted_better;
                 }
 
+                void do_leiden_clustering(PartitionConfig & config, graph_access & G, bool start_w_singletons);
+
         private:
+                bool m_use_leiden;
+                double m_leiden_theta;
 
                 unsigned                m_no_partition_calls;
                 unsigned 		m_population_clustering_size;


### PR DESCRIPTION
## Summary

- Adds `--leiden` CLI flag that guarantees all output communities are connected subgraphs
- Implements the full Leiden algorithm (Traag et al. 2019): queue-based fast local moving, stochastic refinement phase, and dual-partition aggregation
- All evolutionary operators (5 combine + mutation) enforce connectivity via BFS splitting when `--leiden` is active
- No changes to `PartitionConfig` struct; leiden parameters passed via separate `LeidenConfig` to avoid disturbing existing memory layout

## Results (262 graphs, 5s time limit, seed 42)

| Metric | Louvain | Leiden |
|--------|---------|--------|
| Graphs with disconnected communities | 74 (28.2%) | 0 |
| Total disconnected clusters | 2340 | 0 |
| Better modularity | 98 (37.4%) | **151 (57.6%)** |

On the 74 graphs where Louvain produces disconnected communities, Leiden finds better modularity on 62.2% of them.

## Usage

```bash
./evolutionary_clustering graph.graph --leiden --time_limit 120
./evolutionary_clustering graph.graph --leiden --leiden_theta 0.05 --time_limit 120
```

## Test plan

- [x] Builds without errors (`cmake .. && make -j`)
- [x] Without `--leiden`: algorithm runs correctly, no crashes
- [x] With `--leiden`: all output communities verified connected (BFS check on 262 graphs)
- [x] Modularity competitive or better than Louvain
- [x] Tested on meshes, social networks, web graphs, random graphs up to 1.4M nodes